### PR TITLE
feat: Add release action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,43 @@
+name: Release
+
+on:
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        path: project
+    - name: "Prepare Ren'Py cache"
+      id: cache-renpy
+      uses: actions/cache@v3
+      with:
+        path: renpy
+        key: ${{ runner.os }}-renpy
+    - name: "Download Ren'Py"
+      if: steps.cache-renpy.outputs.cache-hit != 'true'
+      run: mkdir renpy && curl https://www.renpy.org/dl/8.0.2/renpy-8.0.2-sdk.tar.bz2 | tar -xjC renpy --strip-components 1
+    - name: Build distribution
+      run: ./renpy/renpy.sh "" distribute project --destination target
+    - name: Publish distribution files - Windows
+      uses: actions/upload-artifact@v3
+      with:
+        name: windows
+        path: target/*-win.zip
+    - name: Publish distribution files - Linux
+      uses: actions/upload-artifact@v3
+      with:
+        name: linux
+        path: target/*-linux.tar.bz2
+    - name: Publish distribution files - Mac
+      uses: actions/upload-artifact@v3
+      with:
+        name: mac
+        path: target/*-mac.zip
+    - name: Publish distribution files - Multi
+      uses: actions/upload-artifact@v3
+      with:
+        name: multi-platform
+        path: target/*-market.zip


### PR DESCRIPTION
Les archives distribuables générées deviendront disponibles sur la page de l'action pendant 90 jours par défaut (réglable dans les paramètres).