### PR TITLE
Updated titlepage to remove the need for multiple conditions and improve versatility

### DIFF
--- a/game/chap/chap0.rpy
+++ b/game/chap/chap0.rpy
@@ -1,30 +1,20 @@
-﻿label titlepage(chapNum):
+﻿label titlepage(chapNum, chap_label = _("Chapitre {}")):
     stop music fadeout 1.0
     scene black with dissolve
-    define chap_label = "Chapter "
     image background_image = "gui/main_menu.png"
 
-    if chapNum == 0:
-        show background_image
-        show expression VBox(Text(_("Prologue"), size=125, yalign=0.5, xalign=0.5, color="#fff")) as text:
-            yalign 0.42
-            xalign 0.5
-        with dissolve
-    else:
-        if persistent.lang is None:
-            $ chap_label = "Chapitre "
-        show background_image
-        show expression VBox(Text(chap_label + str(chapNum), size=125, yalign=0.5, xalign=0.5, color="#fff")) as text:
-            yalign 0.42
-            xalign 0.5
-        with dissolve
+    show background_image
+    show expression VBox(Text(__(chap_label).format(chapNum), substitute = False, size=125, yalign=0.5, xalign=0.5, color="#fff")) as text:
+        yalign 0.42
+        xalign 0.5
+    with dissolve
     $ renpy.pause (2.5)
     return
 
 # Le jeu commence ici
 label start:
     show screen konami_trigger
-    call titlepage(0)
+    call titlepage("", _("Prologue"))
     scene world with dissolve
     $ renpy.pause (2.5)
     "Il était une fois, dans un royaume lointain nommé Couleurs, existaient sept boules de cristal."

--- a/game/screens.rpy
+++ b/game/screens.rpy
@@ -261,24 +261,24 @@ screen quick_menu():
             yalign 0.65
             spacing 30
             # Le _ sert uniquement à flagger pour la génération des fichiers de traduction,
-            # le vrai travail est effectué par renpy.substitutions.substitute
+            # le vrai travail est effectué par __
             imagebutton:
-                auto renpy.substitutions.substitute(_("images/menu/fr_fr/back_%s.png"), None, True)[0]
+                auto __(_("images/menu/fr_fr/back_%s.png"))
                 action Rollback()
             imagebutton:
-                auto renpy.substitutions.substitute(_("images/menu/fr_fr/history_%s.png"), None, True)[0]
+                auto __(_("images/menu/fr_fr/history_%s.png"))
                 action ShowMenu('history')
             imagebutton:
-                auto renpy.substitutions.substitute(_("images/menu/fr_fr/skip_%s.png"), None, True)[0]
+                auto __(_("images/menu/fr_fr/skip_%s.png"))
                 action Skip() alternate Skip(fast=True, confirm=True)
             imagebutton:
-                auto renpy.substitutions.substitute(_("images/menu/fr_fr/auto_%s.png"), None, True)[0]
+                auto __(_("images/menu/fr_fr/auto_%s.png"))
                 action Preference("auto-forward", "toggle")
             imagebutton:
-                auto renpy.substitutions.substitute(_("images/menu/fr_fr/save_%s.png"), None, True)[0]
+                auto __(_("images/menu/fr_fr/save_%s.png"))
                 action ShowMenu('save')
             imagebutton:
-                auto renpy.substitutions.substitute(_("images/menu/fr_fr/settings_%s.png"), None, True)[0]
+                auto __(_("images/menu/fr_fr/settings_%s.png"))
                 action ShowMenu('preferences')
 
 default quick_menu = True
@@ -1162,16 +1162,16 @@ screen quick_menu():
             yalign 1.0
 
             imagebutton:
-                auto renpy.substitutions.substitute(_("images/menu/fr_fr/back_%s.png"), None, True)[0]
+                auto __(_("images/menu/fr_fr/back_%s.png"))
                 action Rollback()
             imagebutton:
-                auto renpy.substitutions.substitute(_("images/menu/fr_fr/skip_%s.png"), None, True)[0]
+                auto __(_("images/menu/fr_fr/skip_%s.png"))
                 action Skip() alternate Skip(fast=True, confirm=True)
             imagebutton:
-                auto renpy.substitutions.substitute(_("images/menu/fr_fr/auto_%s.png"), None, True)[0]
+                auto __(_("images/menu/fr_fr/auto_%s.png"))
                 action Preference("auto-forward", "toggle")
             imagebutton:
-                auto renpy.substitutions.substitute(_("images/menu/fr_fr/settings_%s.png"), None, True)[0]
+                auto __(_("images/menu/fr_fr/settings_%s.png"))
                 action ShowMenu('preferences')
 
 

--- a/game/tl/english/chap/chap0.rpy
+++ b/game/tl/english/chap/chap0.rpy
@@ -110,3 +110,11 @@ translate english strings:
     old "Cheat - Voyage rapide"
     new "Cheat - Voyage rapide"
 
+# TODO: Translation updated at 2022-08-18 18:22
+
+translate english strings:
+
+    # game/chap/chap0.rpy:1
+    old "Chapitre {}"
+    new "Chapter {}"
+


### PR DESCRIPTION
Bon ok, j'ai menti quand j'ai dit qu'il fallait utiliser `renpy.substitutions.substitute`, apparemment c'est `__` qu'il faut utiliser et c'est bien documenté. Je profite de l'utiliser dans titlepage pour corriger pour les chemins d'image.