### PR TITLE
Add fadein and fadeout ranges on Spirited and update documentation

### DIFF
--- a/game/minigames/spirited.rpy
+++ b/game/minigames/spirited.rpy
@@ -1,11 +1,12 @@
 # @Author Ayowel
 init python:
-    import time
     import math
 
-    # Container class for Spirited, should not be used directly
     class SpiritedSpriteInfo():
-        def __init__(self, rid, sprite, speed, direction, roll, roll_offset, duration):
+        """
+        Container class used by Spirited, should not be used directly
+        """
+        def __init__(self, rid, sprite, speed, direction, roll, roll_offset, duration, fadein, fadeout, st):
             # base image id for use by Spirited upon opacity change
             self.rid = rid
             # Whether the sprite is appearing (0), stable (1), or disappearing (2)
@@ -16,80 +17,150 @@ init python:
             self.start_pos = (sprite.x, sprite.y)
             # 0-100, used by increments of 10 in the current implementation
             self.opacity = 0
-            self.birth_time = time.time()
+            self.birth_time = st
             # how long the sprite should stay visible before starting to disappear
             self.duration = duration
             self.sprite = sprite
             self.roll_offset = roll_offset
+            self.fadein = fadein
+            self.fadeout = fadeout
 
-    # This class provides rendering for mostly-linear effects
-    # such as "mystic" particles, rain, or snow
-    #
-    # To render outside of a called scene prefer to use SpiritedInstance
-    #
-    # # Arguments
-    #
-    # sprite_list: An array of images to use as sprites
-    # renewal_rate: On average, how many sprites should be generated per second while the minimum rate is not reached
-    # initial_count: How many sprites should be generated at the start
-    # minimum_pool: Minimum number of sprites that must exist at the same time
-    # maximum_pool: Maximum number of sprites that may exist at the same time
-    # speed_range: how slow/fast a sprite may move
-    # direction_range: Valid direction angle for a sprite (in radians)
-    # roll_range: How far from its base direction line a sprite may "wobble"
-    # ttl_range: How long a sprite may live
-    # bounding_box:
-    #     If != None, screen-relative limits beyond which a sprite WILL be deleted before its lifespan expires in the format (left, top, right, bottom)
-    #     The calculation is performed relative to the top left corner of the sprites
-    # spawn_box:
-    #     If != None, screen-relative limits within which a sprite will be created in the format (left, top, right, bottom)
-    #     The calculation is performed relative to the top left corner of the sprites
-    # repulsor_strength: how fast sprites should run away from the mouse' cursos
-    # repulsor_radius: how far the mouse's position affects sprites
-    # repulsor_hardness: how strong the repulsor is at the max distance compared to on the cursor (as a multiplicator)
-    # repulsor_mode: 0 to have a simple repulsor, 1 to have a tornado that goes woosh, anything else and nothing happens
-    # guideline:
-    #     A custom lambda function that takes four parameters and returns a displacement tuple:
-    #       param1: A SpiritedSpriteInfo instance
-    #       param2: The time ellapsed since the last update in milliseconds
-    #       param3: A tuple that contains the displacement calculated based on Spirited's parameters
-    #               This displacement must be part of the tuple returned by the function to be applied to the sprite
-    #       param4: A tuple that contains the displacement that would be caused by the mouse's cursor's position
-    #               This displacement must be part of the tuple returned by the function to be applied to the sprite
-    #
-    # # Examples
-    #
-    # ```rpy
-    # # This screen will be called
-    # image spirited = Spirited(
-    #         sprite_list = ["images/sprites/light1.png", "images/sprites/light2.png"],
-    #         xsize = 1., ysize = 1.,
-    #         )
-    # screen spirited():
-    #     add 'spirited'
-    #```
-    # ```rpy
-    # # This screen will be shown
-    # image spirited = Spirited(
-    #         instance_name = "forest",
-    #         spirited_args = {
-    #             "sprite_list": ["images/sprites/small_firefly.png", "images/sprites/big_firefly.png", "images/sprites/medium_firefly.png"],
-    #             "renewal_rate": 500,
-    #             "direction_range": (1.2, 1.9),
-    #             "repulsor_strength": 400,
-    #             "repulsor_radius": 300,
-    #         }, xsize = 1., ysize = 1.,
-    #         )
-    # screen spirited():
-    #     add 'spirited'
-    # ```
-    class Spirited(renpy.Displayable):
+    class Spirited(renpy.Displayable, NoRollback):
+        """
+        This class provides rendering for mostly-linear effects
+        such as "mystic" particles, rain, or snow.
+
+        It must be instanciated as an image before usage.
+
+        # Arguments
+
+        `sprite_list`
+            An array of images to use as sprites
+
+        `renewal_rate`
+            On average, how many sprites should be generated per second while the minimum rate is not reached
+
+        `initial_count`
+            How many sprites should be generated at the start
+
+        `minimum_pool`
+            Minimum number of sprites that must exist at the same time
+
+        `maximum_pool`
+            Maximum number of sprites that may exist at the same time
+
+        `speed_range`
+            How slow/fast a sprite may move
+
+        `direction_range`
+            Valid direction angle for a sprite (in radians)
+
+        `roll_range`
+            How far from its base direction line a sprite may "wobble"
+
+        `ttl_range`
+            How long a sprite may live (in seconds)
+
+        `fadein_range`
+            The time it should take for a sprite to reach 100% opacity as it appears (in seconds)
+            This time IS part of the sprite's lifetime (see `ttl_range`)
+
+        `fadeout_range`
+            The time it should take for a sprite to reach 0% opacity as it disappears (in seconds)
+            This time IS NOT part of the sprite's lifetime (see `ttl_range`)
+
+        `bounding_box`
+            If != None, screen-relative limits beyond which a sprite WILL be deleted before its lifespan expires in the format (left, top, right, bottom)
+            The calculation is performed relative to the top left corner of the sprites
+
+        `spawn_box`
+            If != None, screen-relative limits within which a sprite will be created in the format (left, top, right, bottom)
+            The calculation is performed relative to the top left corner of the sprites
+
+        `repulsor_strength`
+            How fast sprites should run away from the mouse' cursor
+
+        `repulsor_radius`
+            How far the mouse's position affects sprites
+
+        `repulsor_hardness`
+            How strong the repulsor is at the max distance compared to on the cursor (as a multiplicator)
+
+        `repulsor_mode`
+            0 to have a simple repulsor
+            1 to have a tornado around the cursor
+            Other values are unsupported
+
+        `guideline`
+            A custom lambda function that takes four parameters and returns a displacement tuple:
+            param1: A SpiritedSpriteInfo instance
+            param2: The time ellapsed since the last update in milliseconds
+            param3: A tuple that contains the displacement calculated based on Spirited's parameters
+                    This displacement must be part of the tuple returned by the function to be applied to the sprite
+            param4: A tuple that contains the displacement that would be caused by the mouse's cursor's position
+                    This displacement must be part of the tuple returned by the function to be applied to the sprite
+
+        # Examples
+
+        Minimal usage example
+
+        ```rpy
+        image spirited = Spirited(
+            sprite_list = ["images/sprites/light1.png", "images/sprites/light2.png"],
+            )
+        screen spirited():
+            add 'spirited'
+        ```
+
+        Make the sprites go up and avoid the mouse cursor
+
+        ```rpy
+        image spirited = Spirited(
+            sprite_list = ["images/sprites/small_firefly.png", "images/sprites/big_firefly.png", "images/sprites/medium_firefly.png"],
+            renewal_rate = 500,
+            direction_range = (1.2, 1.9),
+            repulsor_strength = 400,
+            repulsor_radius = 300,
+            )
+        screen spirited():
+            add 'spirited'
+        ```
+
+        Make it rain from above the screen and disappear around the middle
+
+        ```rpy
+        image spirited = Spirited(
+            sprite_list = ["images/sprites/small_firefly.png", "images/sprites/big_firefly.png", "images/sprites/medium_firefly.png"],
+            initial_count = 500,
+            renewal_rate = 500,
+            speed_range = (10, 150),
+            direction_range = (4.3, 5),
+            ttl_range = (1, 3),
+            spawn_box = (0, -100, 0, -config.screen_height),
+            )
+        screen spirited():
+            add 'spirited'
+        ```
+        """
+        # Initialize internal Displayable library with alpha levels
+        # All displayables are based on sprite_list images
+        image_collection = []
+        image_sizes = []
+        # Cursor position to compute repulsor attributes
+        cursor_pos = (0, 0)
+        # Set of rendered sprites
+        render_set = set()
+        # last render timer
+        last_update = None
+        # Accumulator used to know when to spawn a new sprite
+        accumulated_spawn_odds = 0
+
         def __init__(self,
                 sprite_list, renewal_rate = 30, initial_count = 100, minimum_pool = 0, maximum_pool = None,
                 speed_range = (0, 300), direction_range = (0, math.pi*2), roll_range = (0, 40), ttl_range = (1, 10),
                 bounding_box = (-260, -280, 60, 300), spawn_box = (-20, 50, -80, 300),
                 repulsor_strength = 0, repulsor_radius = 0, repulsor_hardness = 0, repulsor_mode = 0,
-                guideline = None,
+                fadein_range = (0.7, 1.5), fadeout_range = (1, 2), guideline = None,
                 **kwargs,
                 ):
             super(Spirited, self).__init__(**kwargs)
@@ -112,26 +183,23 @@ init python:
             self.repulsor_hardness = repulsor_hardness
             self.repulsor_mode = repulsor_mode
             self.guideline = guideline
+            self.fadein_range = fadein_range
+            self.fadeout_range = fadeout_range
 
-            # Initialize internal Displayable library with alpha levels
-            # All displayables are based on sprite_list images
-            self.image_collection = []
-            self.image_sizes = []
-            # Cursor position to compute repulsor attributes
-            self.cursor_pos = (0, 0)
             # Handle the graphical part with a sprite manager
-            self.manager = SpriteManager()
-            # Set of rendered sprites
-            self.render_set = set() 
-            # last render timer
-            self.last_update = None
-            # Flag used to know if a render already occured
-            self.first_render_time = None
-            # Accumulator used to spawn a new 
-            self.accumulated_spawn_odds = 0
+            self.manager = SpriteManager(update = self.update_sprites, predict = self.manager_predict)
 
-        # Add a new sprite to the internal set
+        def manager_predict(self):
+            """
+            Provided to SpriteManager to predict future displayables
+            """
+            return [i for i in ilist for ilist in self.image_collection]
+
         def new_sprite(self):
+            """
+            Add a new sprite to the internal sprite manager which's characteristics
+            will be randomly generated based on the ranges provided at init
+            """
             if self.maximum_pool is not None and self.maximum_pool <= len(self.render_set):
                 return
             # Pick a reference sprite to use
@@ -152,41 +220,37 @@ init python:
             sprite.x = pos[0]
             sprite.y = pos[1]
             # Initialize other attribute according to configuration
-            speed = renpy.random.randint(self.speed_range[0], self.speed_range[1])
-            direction = renpy.random.random() * (self.direction_range[1] - self.direction_range[0]) + self.direction_range[0]
-            roll = renpy.random.randint(self.roll_range[0], self.roll_range[1])
+            speed = renpy.random.randint(*self.speed_range)
+            direction = renpy.random.uniform(*self.direction_range)
+            roll = renpy.random.randint(*self.roll_range)
             roll_offset = renpy.random.random() * math.pi * 2
-            ttl = renpy.random.random() * (self.ttl_range[1] - self.ttl_range[0]) + self.ttl_range[0]
+            ttl = renpy.random.uniform(*self.ttl_range)
+            # Avoid 0 and negative values as it would be a pain to handle later and would not make sense
+            # We do want to allow them within the random number generation range though
+            fadein_time = max(0.00001, renpy.random.uniform(*self.fadein_range))
+            fadeout_time = max(0.00001, renpy.random.uniform(*self.fadeout_range))
 
             # Instanciate and add the new sprite
             self.render_set.add(
                 SpiritedSpriteInfo(
-                    rid,
-                    sprite,
-                    speed,
-                    direction,
-                    roll,
-                    roll_offset,
-                    ttl,
+                    rid = rid,
+                    sprite = sprite,
+                    speed = speed,
+                    direction = direction,
+                    roll = roll,
+                    roll_offset = roll_offset,
+                    duration = ttl,
+                    st = self.last_update,
+                    fadein = fadein_time,
+                    fadeout = fadeout_time,
                 )
             )
 
-        def first_render(self):
-            for i in range(len(self.base_image_list)):
-                displayable = renpy.displayable(self.base_image_list[i])
-                self.image_collection.append([Transform(child = displayable, alpha = j/100) for j in range(0, 101, 10)])
-            self.image_sizes = [renpy.render(d[0], 0, 0, 0, 0).get_size() for d in self.image_collection]
-
-        def render(self, width, height, st, at):
-            if self.first_render_time is None:
-                self.first_render()
-                # Create the initial sprite
-                # If we create it at init we don't get the initial "pop" effect when using a SpiritedInstance
-                for i in range(self.initial_count):
-                    self.new_sprite()
-                self.last_update = time.time()
-                self.first_render_time = self.last_update
-            current_time = time.time()
+        def update_sprites(self, st):
+            """
+            Provided to SpriteManager to handle sprites updates
+            """
+            current_time = st
             time_diff = current_time - self.last_update
             self.last_update = current_time
             self.accumulated_spawn_odds = self.accumulated_spawn_odds + renpy.random.random() * self.renewal_rate * time_diff
@@ -209,20 +273,19 @@ init python:
                 # Start disappearance for sprites that have reached their TTL
                 if sprite.duration < current_time - sprite.birth_time:
                     sprite.cycle = 2
-                # FIXME: at the moment the opacity changes as fast as the view is rendered/updated instead of being tied to the clock
-                # In most cases it should not make a difference though
                 if sprite.cycle == 0:
-                    # increase opacity as the sprite appears
-                    sprite.opacity = sprite.opacity + 10
+                    # increase opacity as the sprite appears within [0-100] range
+                    sprite.opacity = min(max(sprite.opacity + time_diff * 100 / sprite.fadein, 0), 100)
                     if sprite.opacity >= 100:
                         sprite.cycle = 1
+                        sprite.opacity = 100
                     sprite.sprite.set_child(self.image_collection[sprite.rid][math.floor(sprite.opacity / 10)])
                 elif sprite.cycle == 2:
-                    # Decrease opacity as the sprite disappears
-                    if sprite.opacity <= 10: # The sprite should disappear. Forever
+                    # Decrease opacity as the sprite disappears within [0-100 range]
+                    sprite.opacity = min(max(sprite.opacity - time_diff * 100 / sprite.fadeout, 0), 100)
+                    if sprite.opacity <= 1: # The sprite should disappear. Forever
                         scheduled_deletions.append(sprite)
                         continue
-                    sprite.opacity = sprite.opacity - 10
                     sprite.sprite.set_child(self.image_collection[sprite.rid][math.floor(sprite.opacity / 10)])
                 # Compute reaction to mouse cursor position
                 repulsor = (0, 0)
@@ -266,12 +329,37 @@ init python:
                 for _ in range(self.minimum_pool - len(self.render_set)):
                     self.new_sprite()
 
+        def first_render(self):
+            """
+            Resets sprites context
+            """
+            if len(self.image_collection) == 0:
+                # Create sprite library with different transparency levels
+                for i in range(len(self.base_image_list)):
+                    displayable = renpy.displayable(self.base_image_list[i])
+                    self.image_collection.append([Transform(child = displayable, alpha = j/100) for j in range(0, 101, 10)])
+                self.image_sizes = [renpy.render(d[0], 0, 0, 0, 0).get_size() for d in self.image_collection]
+            # Remove any existing sprite (only happens on new game/save reload after display in a game)
+            for s in self.render_set:
+                s.sprite.destroy()
+            self.render_set = set()
+
+            # Create initial sprites
+            for i in range(self.initial_count):
+                self.new_sprite()
+
+        def render(self, width, height, st, at):
+            if st == 0:
+                self.last_update = st
+                self.first_render()
             # Schedule next update and return rendered view
             renpy.redraw(self, 0.05)
             return self.manager.render(width, height, st, at)
 
-        # Listen for mouve move events
         def event(self, ev, x, y, st):
+            """
+            Listen for mouve move events
+            """
             self.cursor_pos = (x, y)
 
         def visit(self):


### PR DESCRIPTION
- MàJ documentaire pour utiliser le format utilisé par Renpy
- Ajout des paramètres fadein_range et fadeout_range pour gérer la vitesse à laquelle les sprites apparaissent et disparaissent (et suppression du fixme associé à la gestion de l'opacité des sprites)
- Mise à jour des fonctions utilisées pour la génération de nombres aléatoires pour diminuer le nombre de calculs dans le code
- Ajout d'un exemple pour l'usage de la boite de spawn et des TTL dans la documentation
- Déplacement du code de mise à jour des sprites dans une fonction dédiée plutôt que de le laisser dans la fonction de rendue (et intégration avec le SpriteManager plutôt que d'appeler depuis la fonction de rendu)

Oui, c'est un seul commit.