### PR TITLE
Move mulberry search to a dedicated file and refactor to improve maintainability

### DIFF
--- a/game/chap/chap1.rpy
+++ b/game/chap/chap1.rpy
@@ -1,7 +1,7 @@
 ﻿label chap1:
     call titlepage(1)
     scene mulberry_search
-    show mulberry at mulberry_position
+    show screen chap1_mulberry_search()
     show blanche surprised open at left
     with dissolve 
     blanche "Woah ! Tout est violet ! Il y a pleins de fleurs !!!" with vpunch
@@ -108,8 +108,19 @@
     hide blanche
     hide violet
     with dissolve
-    call mulberry_search
-    hide mulberry
+    call screen chap1_mulberry_search("chap1_2", "onclick_mulberry_background")
+
+label onclick_mulberry_background:
+    show screen chap1_mulberry_search()
+    show violet at right
+    violet "Alors tu as trouvé ?"
+    show blanche pout close at left
+    blanche "Pas encore…"
+    hide blanche
+    hide violet
+    call screen  chap1_mulberry_search("chap1_2", "onclick_mulberry_background")
+
+label chap1_2:
     show violet at right
     show blanche smile close at left
     with dissolve
@@ -162,48 +173,3 @@
     with dissolve
     "Les gardes parcourent le jardin des violettes. Ayant perdu Blanche de vue, ils disparaissent par le petit chemin du fond."
     jump chap2
-
-#####
-# Cette section est dédiée à la récupération d'UNE mûre
-# Si vous êtes capables de faire plus court, lâchez-vous
-# Je hais ren'py
-#
-# La mûre est affichée deux fois, une fois en fond pour persister
-# lors des dialogues, et une fois en tant que bouton.
-
-# Chasse à la mûre
-label mulberry_search:
-    if 'mulberry_found' in vars() and mulberry_found:
-        return
-    else:
-        $ mulberry_found = False
-        window hide
-        # La position de cette mûre n'est pas modifiée avec l'autoreload,
-        # il faut faire un cycle de dialogue avant
-        hide mulberry
-        call screen wait_for_mulberry_click
-
-# Gestion du clic sur la mûre ici
-screen wait_for_mulberry_click():
-    button: # Button that covers the whle background
-        action Jump ("onclick_mulberry_background")
-    hbox at mulberry_position:
-        imagebutton:
-            idle "mulberry"
-            hover "mulberry_button"
-            focus_mask True
-            action Jump ("onclick_mulberry")
-    
-label onclick_mulberry:
-    $ mulberry_found = True
-    jump mulberry_search
-
-label onclick_mulberry_background:
-    show mulberry at mulberry_position
-    show violet at right
-    violet "Alors tu as trouvé ?"
-    hide violet
-    show blanche pout close at left
-    blanche "Pas encore…"
-    hide blanche
-    jump mulberry_search

--- a/game/chap/chap1_mulberry_search.rpy
+++ b/game/chap/chap1_mulberry_search.rpy
@@ -1,0 +1,12 @@
+screen chap1_mulberry_search(success_label = None, fail_label = None):
+    if fail_label:
+        button: # Button that covers the whole background
+            action Jump(fail_label)
+    imagebutton:
+        idle "mulberry"
+        xalign 0.97
+        yalign 0.2
+        if success_label:
+            hover "mulberry_button"
+            focus_mask True
+            action Jump(success_label)

--- a/game/variables.rpy
+++ b/game/variables.rpy
@@ -8,10 +8,6 @@ define lake_phishing_fished_boot = False
 define lake_phishing_fished_fish1 = False
 define lake_phishing_fished_fish2 = False
 
-transform mulberry_position:
-    xalign 0.97
-    yalign 0.2
-
 transform crystal_position:
     xalign 0.5
     yalign 0.5


### PR DESCRIPTION
* Déplacement de l'écran de la recherche de mure dans un fichier dédié
* Refactorisation pour la lisibilité du fichier de narration
* Généralisation de l'écran de recherche de la mûre pour supprimer le code de plomberie autour (suppression de la moitié des lignes avec gain de fonctionnalités)