### PR TITLE
Enable renpy host language autodetect

### DIFF
--- a/game/gui.rpy
+++ b/game/gui.rpy
@@ -259,6 +259,7 @@ define gui.file_slot_rows = 2
 
 ## Langue ################################################
 define config.default_language = "english"
+define config.enable_language_autodetect = True
 
 ## Positionnement et espacement ################################################
 ##


### PR DESCRIPTION
A tester sur un pc en français, après suppression de games/saves et ~/.renpy, je n'ai que des locales en anglais et ça semble fonctionner