### PR TITLE
Feature/simon keyboard

### DIFF
--- a/game/chap/chap7_simon.rpy
+++ b/game/chap/chap7_simon.rpy
@@ -4,10 +4,10 @@ screen chap7_simon_says(next_label, previous_label):
             return Play('sound', sound.Arrow[i%len(sound.Arrow)])
     default simon = SimonGame(
         buttons = [
-            {"auto": "images/items/arrows/Fl_bottom_%s.png", "xalign": 0.5, "yalign": 0.8, "action": button_action(0)},
-            {"auto": "images/items/arrows/Fl_up_%s.png", "xalign": 0.5, "yalign": 0.2, "action": button_action(1)},
-            {"auto": "images/items/arrows/Fl_left_%s.png", "xalign": 0.3, "yalign": 0.5, "action": button_action(2)},
-            {"auto": "images/items/arrows/Fl_right_%s.png", "xalign": 0.7, "yalign": 0.5, "action": button_action(3)},
+            {"auto": "images/items/arrows/Fl_bottom_%s.png", "keysym": "K_DOWN", "xalign": 0.5, "yalign": 0.8, "action": button_action(0)},
+            {"auto": "images/items/arrows/Fl_up_%s.png", "keysym": "K_UP", "xalign": 0.5, "yalign": 0.2, "action": button_action(1)},
+            {"auto": "images/items/arrows/Fl_left_%s.png", "keysym": "K_LEFT", "xalign": 0.3, "yalign": 0.5, "action": button_action(2)},
+            {"auto": "images/items/arrows/Fl_right_%s.png", "keysym": "K_RIGHT", "xalign": 0.7, "yalign": 0.5, "action": button_action(3)},
         ],
         completion_action = Jump(next_label),
         failure_action = Jump(previous_label),


### PR DESCRIPTION
Fix #196 
Ajoute le support des touches du clavier sur les boutons du simon.
L'absence de retour visuel est du fait de Ren'Py et ne sera pas fix programmatiquement.