### PR TITLE
Fix/user name prompt

### DIFF
--- a/game/screens.rpy
+++ b/game/screens.rpy
@@ -183,6 +183,10 @@ init python:
 ##
 ## https://www.renpy.org/doc/html/screen_special.html#input
 
+init python:
+    def return_input_content(screen = 'input', id = 'input'):
+        return renpy.get_widget('input', 'input').content
+
 # Dans notre cas, cet écran est uniquement utilisé pour demander le nom du personnage principal
 screen input(prompt):
     text prompt align (0.5, 0.14) size 62
@@ -206,7 +210,7 @@ screen input(prompt):
     imagebutton:
         align (0.99, 0.5)
         auto "continue_button_%s"
-        action Return(renpy.get_widget('input', 'input').content)
+        action Function(return_input_content)
 
 style idcard_prompt:
     min_width 600

--- a/game/variables.rpy
+++ b/game/variables.rpy
@@ -1,17 +1,17 @@
-define player_name = "Blanche"
+default player_name = "Blanche"
 define chap2_stars = [('star_pisces', _('Pisces')), ('star_leo', _('Leo')), ('star_volans', _('Volans')), ('star_piscis_austrinus', _('Piscis austrinus'))]
-define encore = ""
-define good = 0
-define neutral = 0
-define bad = 0
+default encore = ""
+default good = 0
+default neutral = 0
+default bad = 0
 
 default tutorial_boot_found = False
 
-define lake_phishing_talked_axolotl = 0
-define lake_phishing_fished_axolotl = False
-define lake_phishing_fished_boot = False
-define lake_phishing_fished_fish1 = False
-define lake_phishing_fished_fish2 = False
+default lake_phishing_talked_axolotl = 0
+default lake_phishing_fished_axolotl = False
+default lake_phishing_fished_boot = False
+default lake_phishing_fished_fish1 = False
+default lake_phishing_fished_fish2 = False
 
 default image_cutter_time_factor = 1.
 


### PR DESCRIPTION
* Passage de toutes les variables modifiées durant la narration en 'default' au lieu de 'define'
* Modification de l'écran d'input pour récupérer le texte saisi au moment du clic plutôt qu'à l'affichage de l'écran

Chez moi, l'écran ressemble à ça et tous les fichiers sont commités:
![image](https://user-images.githubusercontent.com/8655467/231689570-f1f08160-087d-4891-ad9e-32ef5cd6888b.png)
