### PR TITLE
Feature/2023 occilan feedback

### DIFF
--- a/.github/workflows/publish_android.yml
+++ b/.github/workflows/publish_android.yml
@@ -1,0 +1,108 @@
+name: Build android distribution
+on:
+  workflow_dispatch:
+    inputs:
+      version_number:
+        description: 'The version to release. A matching tag prefixed with "v" MUST exist'
+        required: true
+        type: string
+      itch_release:
+        description: Release to itch
+        default: true
+        type: boolean
+      upload_aab_artifact:
+        description: Add AAB artifact
+        default: true
+        type: boolean
+      upload_apk_artifact:
+        description: Add APK artifact
+        default: false
+        type: boolean
+
+env:
+  # Required because GitHub-hosted runners provide an incompatible NDK
+  ANDROID_NDK_HOME: ""
+  RENPY_VERSION: ${{ vars.RENPY_VERSION || '8.1.3' }}
+
+jobs:
+  android_build:
+    runs-on: ubuntu-latest
+    name: Android package build
+
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          ref: v${{ inputs.version_number }}
+          path: project
+      - uses: actions/setup-java@v3
+        with:
+          distribution: 'adopt-hotspot'
+          java-version: '8'
+      - name: Create keystore
+        run: base64 -d <<<"$ANDROID_KEYSTORE" >android.keystore
+        env:
+          ANDROID_KEYSTORE: ${{ secrets.ANDROID_KEYSTORE }}
+      - name: "Lookup Ren'Py cache"
+        id: cache-renpy
+        uses: actions/cache@v3
+        with:
+          path: renpy
+          key: ${{ runner.os }}-renpy-${{ env.RENPY_VERSION }}-android
+      - name: "Install Ren'Py"
+        uses: Ayowel/renpy-setup-action@v2
+        if: steps.cache-renpy.outputs.cache-hit != 'true'
+        with:
+          action: install
+          install_dir: renpy
+          version: ${{ env.RENPY_VERSION }}
+          dlc: rapt
+          android_sdk: true
+          android_properties: |
+            key.alias=${{ vars.ANDROID_KEYSTORE_ALIAS || 'android' }}
+            key.store.password=${{ secrets.ANDROID_KEYSTORE_PASSWORD || 'android' }}
+            key.alias.password=${{ secrets.ANDROID_ALIAS_PASSWORD || 'android' }}
+            key.store=${{ github.workspace }}/android.keystore
+
+      - name: Build android AAB file
+        uses: Ayowel/renpy-setup-action@v2
+        if: inputs.upload_aab_artifact
+        with:
+          action: android_build
+          install_dir: renpy
+          build_type: aab
+          game: project
+          out_dir: target
+
+      - name: Build android APK file
+        uses: Ayowel/renpy-setup-action@v2
+        if: inputs.itch_release || inputs.upload_apk_artifact
+        with:
+          action: android_build
+          install_dir: renpy
+          build_type: apk
+          game: project
+          out_dir: target
+
+      - name: Make Play Store build available as workflow artifact
+        uses: actions/upload-artifact@v3
+        if: inputs.upload_aab_artifact
+        with:
+          name: Colors_${{ inputs.version_number }}_android_aab
+          path: target/*.aab
+
+      - name: Make Universal APK build available as workflow artifact
+        uses: actions/upload-artifact@v3
+        if: inputs.upload_apk_artifact
+        with:
+          name: Colors_${{ inputs.version_number }}_android_apk
+          path: target/*.apk
+
+      - name: Push APK build to itch.io
+        uses: Ayowel/butler-to-itch@v1.0.0
+        if: inputs.itch_release
+        with:
+          butler_key: ${{ secrets.BUTLER_CREDENTIALS }}
+          itch_game: ${{ vars.ITCH_GAME }}
+          itch_user: ${{ vars.ITCH_USER }}
+          files: mobile target/*.apk
+          version: ${{ inputs.version_number }}

--- a/.github/workflows/release_tag.yml
+++ b/.github/workflows/release_tag.yml
@@ -15,6 +15,16 @@ jobs:
     - uses: actions/checkout@v3
     - name: Update recorded version
       run: sed -i -Ee 's/(config.version\s*=\s*")[^"]+"/\1${{ inputs.version_number }}"/g' game/options.rpy
+    - name: Update android version
+      run: |
+        python3 - <<EOF
+        import json
+        with open("android.json", "r") as f:
+            content = json.loads(f.read())
+        content["version"] = "${{ inputs.version_number }}"
+        with open("android.json", "w") as f:
+            f.write(json.dumps(content, sort_keys=True, indent=4))
+        EOF
     - run: git diff
     - name: Commit files changes
       uses: EndBug/add-and-commit@v9

--- a/android.json
+++ b/android.json
@@ -1,0 +1,24 @@
+{
+    "expansion": false,
+    "google_play_key": null,
+    "google_play_salt": null,
+    "heap_size": "3",
+    "icon_name": "Couleurs",
+    "include_pil": false,
+    "include_sqlite": false,
+    "layout": null,
+    "name": "Couleurs",
+    "numeric_version": 1,
+    "orientation": "sensorLandscape",
+    "package": "com.kiminako.colors",
+    "permissions": [
+        "VIBRATE",
+        "INTERNET"
+    ],
+    "source": false,
+    "store": "all",
+    "update_always": true,
+    "update_icons": true,
+    "update_keystores": false,
+    "version": "1.4.0"
+}

--- a/game/chap/chap5_cupboard.rpy
+++ b/game/chap/chap5_cupboard.rpy
@@ -224,9 +224,10 @@ screen cheese_market(next_label, fail_scene):
         drag:
             drag_name "cheese_basket"
             child "cheese_market_basket"
+            draggable False
             drag_offscreen True
             focus_mask True
-            xpos 850 ypos 680
+            xpos 840 ypos 650
     # Show expected cheese
     if current_index < len(cheese_request_list):
         image "cheese_market_entrance_" + cheese_request_list[current_index]:

--- a/game/chap/chap7_simon.rpy
+++ b/game/chap/chap7_simon.rpy
@@ -12,6 +12,7 @@ screen chap7_simon_says(next_label, previous_label):
         completion_action = Jump(next_label),
         failure_action = Jump(previous_label),
         generated_len = 5,
+        downtime_duration = 0.3,
     )
     add simon
     textbutton _("Remontrer"):

--- a/game/minigames/simon_game.rpy
+++ b/game/minigames/simon_game.rpy
@@ -165,16 +165,16 @@ init python:
                 self.toggle_buttons(False)
                 self.show_is_uptime = False
                 self.show_ruleset_index = 0
-                self.next_auto_update = self.time_draw + self.downtime_duration
-                renpy.redraw(self, self.downtime_duration)
+                self.next_auto_update = self.time_draw + self.uptime_duration
+                renpy.redraw(self, self.uptime_duration)
             elif self.show_is_uptime:
                 # A button was lit, shut it down
                 self.show_is_uptime = False
                 self.toggle_image(self.ruleset[self.show_ruleset_index], is_hovered = False)
                 self.show_ruleset_index = self.show_ruleset_index + 1
-                self.next_auto_update = self.time_draw + self.uptime_duration
+                self.next_auto_update = self.time_draw + self.downtime_duration
 
-                renpy.redraw(self, self.uptime_duration)
+                renpy.redraw(self, self.downtime_duration)
             else:
                 # No button was lit
                 if self.current_simon_len <= self.show_ruleset_index:
@@ -187,8 +187,8 @@ init python:
                     # Light it up
                     self.toggle_image(self.ruleset[self.show_ruleset_index], is_hovered = True)
                     self.show_is_uptime = True
-                    self.next_auto_update = self.time_draw + self.downtime_duration
-                    renpy.redraw(self, self.downtime_duration)
+                    self.next_auto_update = self.time_draw + self.uptime_duration
+                    renpy.redraw(self, self.uptime_duration)
 
         def goto_next_ruleset(self):
             """

--- a/game/tl/english/chap/chap1.rpy
+++ b/game/tl/english/chap/chap1.rpy
@@ -328,7 +328,7 @@ translate english onclick_mulberry_background_00e2abfb:
     # voice renpy.random.choice(audio.Violet_Speak)
     # violet "Alors tu as trouvé ?"
     voice renpy.random.choice(audio.Violet_Speak)
-    violet "Have you found it?"
+    violet "Have you found the mulberry? It's big and shiny."
 
 # game/chap/chap1.rpy:144
 translate english onclick_mulberry_background_a7ac74fd:

--- a/game/tl/english/characters.rpy
+++ b/game/tl/english/characters.rpy
@@ -29,7 +29,7 @@
 
     # game/characters.rpy:45
     old "Caméraman"
-    new "Cameraman"
+    new "Catmeraman"
 
     # game/characters.rpy:46
     old "Cyan"

--- a/game/tl/french/chap/chap1.rpy
+++ b/game/tl/french/chap/chap1.rpy
@@ -363,7 +363,7 @@ translate french onclick_mulberry_background_00e2abfb:
     # voice renpy.random.choice(audio.Violet_Speak)
     # violet "Alors tu as trouvé ?"
     voice renpy.random.choice(audio.Violet_Speak)
-    violet "Alors tu as trouvé ?"
+    violet "Alors, tu as trouvé la mûre ? Elle est brillante et bien grosse."
 
 # game/chap/chap1.rpy:144
 translate french onclick_mulberry_background_a7ac74fd:

--- a/game/tl/french/characters.rpy
+++ b/game/tl/french/characters.rpy
@@ -30,7 +30,7 @@
 
     # game/characters.rpy:52
     old "Caméraman"
-    new "Chaméraman"
+    new "Chatméraman"
 
     # game/characters.rpy:53
     old "Cyan"

--- a/game/tl/french/characters.rpy
+++ b/game/tl/french/characters.rpy
@@ -30,7 +30,7 @@
 
     # game/characters.rpy:52
     old "Caméraman"
-    new "Caméraman"
+    new "Chaméraman"
 
     # game/characters.rpy:53
     old "Cyan"


### PR DESCRIPTION
* Ajout de releases android (variables & secrets à configurer)
* Le caméraman  devient chaméraman
* Le message en cas de clic sur autre chose que la mûre voulue dans le chapitre 1 est plus complet
* Le panier dans l'armoire de fromages n'est plus déplaçable et est légèrement plus haut
* Le temps d'attente entre deux exemples du Simon says est plus court

Pour mémoire, les attendus du script de build android:

Requiert de créer les secrets :

* `ANDROID_KEYSTORE`, qui sera la base 64 du fichier keystore contenant la clé privée à utiliser
* `ANDROID_KEYSTORE_PASSWORD`, qui sera le mot de passe du keystore
* `ANDROID_ALIAS_PASSWORD`, qui sera le mot de passe de la clé dans le keystore
* `PLAY_STORE_JSON`, qui est un JSON qui doit servir à authentifier un compte de service (voir https://support.google.com/a/answer/7378726?hl=en ).

Et les variables :

* `ANDROID_KEYSTORE_ALIAS`, qui sera l'alias de la clé dans le keystore
* `ITCH_GAME`, qui devrait valoir colors
* `ITCH_USER`, qui devrait valoir kiminako
