### PR TITLE
feat(workflows): Make Ren'Py version configureable

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -5,6 +5,9 @@ on:
   pull_request:
   workflow_dispatch:
 
+env:
+  RENPY_VERSION: ${{ vars.RENPY_VERSION || '8.3.6' }}
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -17,9 +20,13 @@ jobs:
       uses: actions/cache@v3
       with:
         path: renpy
-        key: ${{ runner.os }}-renpy
-    - name: "Download Ren'Py"
+        key: ${{ runner.os }}-renpy-${{ env.RENPY_VERSION }}-core
+    - name: "Install Ren'Py"
+      uses: Ayowel/renpy-setup-action@v2
       if: steps.cache-renpy.outputs.cache-hit != 'true'
-      run: mkdir renpy && curl https://www.renpy.org/dl/8.0.2/renpy-8.0.2-sdk.tar.bz2 | tar -xjC renpy --strip-components 1
+      with:
+        action: install
+        install_dir: renpy
+        version: ${{ env.RENPY_VERSION }}
     - name: Lint
       run: ./renpy/renpy.sh project lint --error-code

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,6 +16,9 @@ on:
         default: true
         type: boolean
 
+env:
+  RENPY_VERSION: ${{ vars.RENPY_VERSION || '8.3.6' }}
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -30,10 +33,14 @@ jobs:
       uses: actions/cache@v3
       with:
         path: renpy
-        key: ${{ runner.os }}-renpy
-    - name: "Download Ren'Py"
+        key: ${{ runner.os }}-renpy-${{ env.RENPY_VERSION }}-core
+    - name: "Install Ren'Py"
+      uses: Ayowel/renpy-setup-action@v2
       if: steps.cache-renpy.outputs.cache-hit != 'true'
-      run: mkdir renpy && curl https://www.renpy.org/dl/8.0.2/renpy-8.0.2-sdk.tar.bz2 | tar -xjC renpy --strip-components 1
+      with:
+        action: install
+        install_dir: renpy
+        version: ${{ env.RENPY_VERSION }}
     - name: Build distribution
       run: ./renpy/renpy.sh "" distribute project --package mac --package win --package linux --destination target
 

--- a/.github/workflows/publish_android.yml
+++ b/.github/workflows/publish_android.yml
@@ -22,7 +22,7 @@ on:
 env:
   # Required because GitHub-hosted runners provide an incompatible NDK
   ANDROID_NDK_HOME: ""
-  RENPY_VERSION: ${{ vars.RENPY_VERSION || '8.1.3' }}
+  RENPY_VERSION: ${{ vars.RENPY_VERSION || '8.3.6' }}
 
 jobs:
   android_build:

--- a/.github/workflows/translate.yml
+++ b/.github/workflows/translate.yml
@@ -6,6 +6,9 @@ on:
       - main
   workflow_dispatch:
 
+env:
+  RENPY_VERSION: ${{ vars.RENPY_VERSION || '8.3.6' }}
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -18,10 +21,14 @@ jobs:
       uses: actions/cache@v3
       with:
         path: renpy
-        key: ${{ runner.os }}-renpy
-    - name: "Download Ren'Py"
+        key: ${{ runner.os }}-renpy-${{ env.RENPY_VERSION }}-core
+    - name: "Install Ren'Py"
+      uses: Ayowel/renpy-setup-action@v2
       if: steps.cache-renpy.outputs.cache-hit != 'true'
-      run: mkdir renpy && curl https://www.renpy.org/dl/8.0.2/renpy-8.0.2-sdk.tar.bz2 | tar -xjC renpy --strip-components 1
+      with:
+        action: install
+        install_dir: renpy
+        version: ${{ env.RENPY_VERSION }}
     - name: Update translation files - English
       run: ./renpy/renpy.sh project translate english
     - name: Update translation files - French


### PR DESCRIPTION
* In all workflows, get Ren'Py version from project var RENPY_VERSION
* Use Ayowel/renpy-setup-action@v2 instead of shell script to support version download from GitHub when available
* Update cache name to ensure that it is refreshed on version update